### PR TITLE
fix: disable irrelevant custom domain and skin section

### DIFF
--- a/src/components/SetupExtras.vue
+++ b/src/components/SetupExtras.vue
@@ -24,7 +24,7 @@ function handleSubmit() {
 
     <SettingsVotingBlock context="setup" />
 
-    <SettingsDomainBlock context="setup" />
+    <!-- <SettingsDomainBlock context="setup" /> -->
 
     <SettingsSubSpacesBlock context="setup" />
 

--- a/src/views/SpaceSettings.vue
+++ b/src/views/SpaceSettings.vue
@@ -303,10 +303,10 @@ onBeforeRouteLeave(async () => {
               context="settings"
               :is-view-only="isViewOnly"
             />
-            <SettingsDomainBlock
+            <!-- <SettingsDomainBlock
               context="settings"
               :is-view-only="isViewOnly"
-            />
+            /> -->
             <SettingsDangerzoneBlock
               :is-controller="isSpaceController"
               :ens-owner="ensOwner"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/362

This PR will disable the custom domain and skin section in the space settings, since it's not relevant anymore:

- the docs are outdated
- custom domain does not work on v1
- skin does not work on v1

### How to test

1. Go to a space settings, then advanced
2. The section about custom domain and skin is gone
