### PR TITLE
fix: hardcode strategies limits

### DIFF
--- a/src/components/SettingsStrategiesBlock.vue
+++ b/src/components/SettingsStrategiesBlock.vue
@@ -2,6 +2,7 @@
 import { SpaceStrategy } from '@/helpers/interfaces';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
 import schemas from '@snapshot-labs/snapshot.js/src/schemas';
+import { STRATEGIES_LIMITS } from '@/helpers/constants';
 
 const spaceSchema = schemas.space;
 
@@ -18,7 +19,7 @@ const { form, validationErrors } = useFormSpaceSettings(props.context, {
 });
 
 const strategiesLimit = computed(
-  () => spaceSchema.properties.strategies.maxItemsWithSpaceType[props.spaceType]
+  () => STRATEGIES_LIMITS[props.spaceType || 'default']
 );
 const strategies = computed(() => form.value.strategies);
 

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -126,3 +126,9 @@ export const BOOST_ENABLED_VOTING_TYPES = [
   'single-choice',
   'ranked-choice'
 ];
+
+export const STRATEGIES_LIMITS = {
+  default: 8,
+  verified: 8,
+  turbo: 10
+};


### PR DESCRIPTION
### Summary
Issue:
![image](https://github.com/user-attachments/assets/7152b6d5-d7fa-4d6b-9e2b-3b1881c7157a)
Fix:
Snapshot.js doesn't contain these limits anymore

### How to test

1. Go to http://localhost:8080/#/moonwell-governance.eth you should see limit of 10 on strategies
2. Go to http://localhost:8080/#/mutantcatsvote.eth/settings you should see limit of 8 on strategies

