### PR TITLE
fix: hardcode proposal body limits

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -132,3 +132,8 @@ export const STRATEGIES_LIMITS = {
   verified: 8,
   turbo: 10
 };
+
+export const PROPOSAL_BODY_LIMITS = {
+  default: 10000,
+  turbo: 40000
+};

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -5,7 +5,7 @@ import { proposalValidation } from '@/helpers/snapshot';
 import Plugin from '@/plugins/safeSnap';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { clone } from '@snapshot-labs/snapshot.js/src/utils';
-import proposalSchema from '@snapshot-labs/snapshot.js/src/schemas/proposal.json';
+import { PROPOSAL_BODY_LIMITS } from '@/helpers/constants';
 
 const safeSnapPlugin = new Plugin();
 
@@ -21,10 +21,7 @@ const props = defineProps<{
 
 const spaceType = computed(() => (props.space.turbo ? 'turbo' : 'default'));
 const bodyCharactersLimit = computed(
-  () =>
-    proposalSchema.definitions.Proposal.properties.body.maxLengthWithSpaceType[
-      spaceType.value
-    ]
+  () => PROPOSAL_BODY_LIMITS[spaceType.value]
 );
 
 useMeta({


### PR DESCRIPTION
## Summary:

Unable to create proposals because snapshot.js doesn't contain these limits

## how to test:
- http://localhost:8080/#/moonwell-governance.eth/create Body limit should be 40k
- http://localhost:8080/#/friendswithbenefits.eth/create Body limit should be 10k