### PR TITLE
Fix typos

### DIFF
--- a/src/plugins/projectGalaxy/README.md
+++ b/src/plugins/projectGalaxy/README.md
@@ -2,7 +2,7 @@
 
 Created time: July 21, 2022 5:51 PM
 
-The **Galxe Plugin is designed for Snapshot.org. This will incentivize communities to participate in the proposal vote by rewarding them with OATs (On-Chain Achievement Tokens). Space Admin can add this plugin into your space. After users vote, they can claim an OAT directly from the Galxe Plugin section on the proposal page.**
+The **Galxe Plugin is designed for Snapshot.org. This will incentivize communities to participate in the proposal vote by rewarding them with OATs (On-Chain Achievement Tokens).A Space Admin can add this plugin to your space. After users vote, they can claim an OAT directly from the Galxe Plugin section on the proposal page.**
 
 ### 1. Preparation
 
@@ -32,7 +32,7 @@ _Specific JSON format like this, and you could use more than 1 OAT in your space
 }
 ```
 
-notice: The domain should not included in <Space Name>.
+notice: The domain should not be included in <Space Name>.
 
 #### Usually you don't need to change api part unless you know which api you are using.
 

--- a/src/plugins/projectGalaxy/index.ts
+++ b/src/plugins/projectGalaxy/index.ts
@@ -80,7 +80,7 @@ export default class Plugin {
         }
       }
     });
-    // If the fetch fails: the event doesn't exists for this poap yet
+    // If the fetch fails: the event doesn't exist for this poap yet
     if (!eventResponse.ok) {
       return { currentState: 'NO_OAT' };
     }


### PR DESCRIPTION
1. Changes in README.md
Modified Sentence in Introduction
Old: Space Admin can add this plugin into your space.
New: A Space Admin can add this plugin to your space.
Reason: The phrase "into your space" was replaced with "to your space" because "add to" is the correct collocation in English. Also, "A Space Admin" was added for grammatical correctness.
Fixed Grammar in Notice Section
Old: notice: The domain should not included in <Space Name>.
New: notice: The domain should not be included in <Space Name>.
Reason: The verb "included" was missing the auxiliary verb "be", making the sentence grammatically incorrect.
2. Changes in index.ts
Fixed Grammar in Comment
Old: // If the fetch fails: the event doesn't exists for this poap yet
New: // If the fetch fails: the event doesn't exist for this poap yet
Reason:
"doesn't exists" → "doesn't exist": The verb "exist" should be in its base form after "doesn't."
