### PR TITLE
fix: use space privacy on proposal

### DIFF
--- a/src/composables/useClient.ts
+++ b/src/composables/useClient.ts
@@ -56,6 +56,7 @@ export function useClient() {
         start: payload.start,
         end: payload.end,
         snapshot: payload.snapshot,
+        privacy: payload.privacy,
         plugins: JSON.stringify(plugins),
         app: DEFINED_APP
       });
@@ -69,6 +70,7 @@ export function useClient() {
         discussion: payload.discussion,
         choices: payload.choices,
         labels: payload.labels,
+        privacy: payload.privacy,
         plugins: JSON.stringify(plugins)
       });
     } else if (type === 'vote') {

--- a/src/views/SpaceCreate.vue
+++ b/src/views/SpaceCreate.vue
@@ -239,6 +239,8 @@ function getFormattedForm() {
     });
   clonedForm.start = sanitizedDateStart;
   clonedForm.end = sanitizedDateEnd;
+  clonedForm.privacy =
+    props.space.voting.privacy === 'any' ? '' : props.space.voting.privacy;
   return clonedForm;
 }
 


### PR DESCRIPTION
### Summary
We don't have privacy selector on v1, so we send space's privacy and empty string if it is `any`


Closes https://github.com/snapshot-labs/workflow/issues/453

### How to test

1. Go to space with privacy `shutter` 
2. Create a proposal
3. Proposal payload should contain `privacy: 'shutter'`
