### PR TITLE
chore: update strategies link

### DIFF
--- a/src/views/StrategyView.vue
+++ b/src/views/StrategyView.vue
@@ -66,7 +66,7 @@ onMounted(async () => {
             <b>{{ $t('version') }}</b>
             <BaseLink
               class="float-right"
-              :link="`https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/${strategy.id}`"
+              :link="`https://github.com/snapshot-labs/score-api/tree/master/src/strategies/strategies/${strategy.id}`"
             >
               {{ strategy.version }}
             </BaseLink>


### PR DESCRIPTION
### Summary
The Strategies link in https://v1.snapshot.box/#/strategy/sonic-staked-balance is not working, this page is still being shared to others to refer to the strategy