### PR TITLE
fix: switch to ES module export in tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 import formsPlugin from '@tailwindcss/forms';
 
-module.exports = {
+export default {
   content: ['./index.html', './src/**/*.{js,ts,vue}'],
   theme: {
     extend: {


### PR DESCRIPTION
### Issue
It stopped working with newer versions of node js

### Summary
- changed module.exports to export default in tailwind.config.js


### How to test

1. run `yarn dev`
2. open localhost:8080
3. before it fail with error `ReferenceError: module is not defined`

